### PR TITLE
add support to stopwatch activity by checking not None distance

### DIFF
--- a/gcexport.py
+++ b/gcexport.py
@@ -439,7 +439,7 @@ while total_downloaded < total_to_download:
 			print hhmmssFromSeconds(a['duration']) + ',',
 		else:
 			print '??:??:??,',
-		if 'distance' in a:
+		if 'distance' in a and a['distance']:
 			print "{0:.3f}".format(a['distance']/1000)
 		else:
 			print '0.000 km'


### PR DESCRIPTION
Stopwatch activity  ( ['activityType']['typeId'] == 151 ) has a "distance" field but it's none so the operation a['distance']/1000 throws a NoneType and int unsuported operation

stack:
Traceback (most recent call last):
  File "./gcexport.py", line 445, in <module>
    print "{0:.3f}".format(a['distance']/1000)
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'